### PR TITLE
Feat/respawn complete

### DIFF
--- a/hestia/Dockerfile
+++ b/hestia/Dockerfile
@@ -1,4 +1,5 @@
 FROM docker:latest
+RUN apk add bash
 COPY ./hestia /app/hestia
 WORKDIR /app
 ENTRYPOINT ["/app/hestia"]

--- a/hestia/Makefile
+++ b/hestia/Makefile
@@ -2,3 +2,9 @@
 
 image:
 	docker build . -t hestia:latest
+
+debug: image
+	docker run -it --entrypoint sh -v `pwd`:/app hestia:latest
+
+debug-no-mount: image
+	docker run -it --entrypoint sh hestia:latest

--- a/ouroborus/Dockerfile
+++ b/ouroborus/Dockerfile
@@ -9,6 +9,7 @@ RUN bundle package --all
 FROM ruby:3-alpine
 EXPOSE 8000
 WORKDIR /app 
+RUN apk update && apk add docker
 
 #Copying webrick gem already pulled from git
 COPY --from=build /app /app

--- a/ouroborus/Makefile
+++ b/ouroborus/Makefile
@@ -1,19 +1,20 @@
 .PHONY: run debug debug-no-mount image prune debug-as-ruby
 
+DOCKER_SOCKET_BIND=-v /var/run/docker.sock:/var/run/docker.sock
 PORT=8000
 PORT_BIND=-p $(PORT):$(PORT)
 
 run: image
-	docker run -it $(PORT_BIND) ouroborus:latest
+	docker run --restart unless-stopped -it $(PORT_BIND) $(DOCKER_SOCKET_BIND) ouroborus:latest
 
 debug: image
-	docker run -it $(PORT_BIND) --entrypoint sh -v `pwd`:/app ouroborus:latest
+	docker run -it $(PORT_BIND) $(DOCKER_SOCKET_BIND) --entrypoint sh -v `pwd`:/app ouroborus:latest
 
 debug-as-ruby:
-	docker run -it $(PORT_BIND) --entrypoint sh -v `pwd`:/app ruby:3-alpine
+	docker run -it $(PORT_BIND) $(DOCKER_SOCKET_BIND) --entrypoint sh -v `pwd`:/app ruby:3-alpine
 
 debug-no-mount: image
-	docker run -it $(PORT_BIND) --entrypoint sh ouroborus:latest
+	docker run -it $(PORT_BIND) $(DOCKER_SOCKET_BIND) --entrypoint sh ouroborus:latest
 
 image: Dockerfile Gemfile Gemfile.lock ouroborus.gemspec
 	docker build . -t ouroborus:latest

--- a/ouroborus/lib/ouroborus.rb
+++ b/ouroborus/lib/ouroborus.rb
@@ -16,6 +16,28 @@ class ShutDownServlet < WEBrick::HTTPServlet::AbstractServlet
   end
 end
 
+class RespawnServlet < WEBrick::HTTPServlet::AbstractServlet
+  def initialize server, suicide_squad, port
+    super server
+    @suicide_squad = suicide_squad
+    @port = port
+  end
+  def do_PUT request, response
+    response.status = 200
+    response.content_type = "text/plain"
+    response.body = hestia
+
+    @suicide_squad.call
+  end
+
+  def hestia
+    docker_socket = "/var/run/docker.sock"
+    docker_socket_bind = "-v #{docker_socket}:#{docker_socket}"
+    port_bind = "-p #{@port}:#{@port}"
+    `docker run -d #{docker_socket_bind} hestia -- run -d --restart unless-stopped #{port_bind} #{docker_socket_bind} ouroborus:latest`
+  end
+end
+
 def ouroborus_server(port = 8000)
   server = WEBrick::HTTPServer.new :Port => port
 
@@ -43,10 +65,13 @@ def ouroborus_server(port = 8000)
     end
   }
   server.mount '/shutdown', ShutDownServlet, suicide_squad
+  server.mount '/respawn', RespawnServlet, suicide_squad, port
   puts 'montou servlet'
 
   trap 'INT' do server.shutdown end
 
   puts 'iniciando o server'
   server.start
+  hostname=`hostname`
+  puts `docker stop #{hostname}`
 end


### PR DESCRIPTION
Closes #2 

-----

## How to test

This assumes user capable of running `docker` commands.

Open 2 distinct terminals, A and B.

Terminal A:

```bash
make
make -C ouroborus
```

The first command will build both images, both are needed indeed. The second command will start ouroborus server.

Terminal B (must exec after both Terminal A commands):

```bash
curl localhost:8000/respawn -X PUT
for a in 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5; do
  docker ps
  echo
  sleep 1
done
```

Curl will send a message for ouroborus respawn itself. Than, one can follow what is happening by the repetition
of `docker ps` command.