### PR TITLE
CI to publish Ouroborus Gem on Github Packages

### DIFF
--- a/.github/workflows/gem_deploy_ouroborus.yml
+++ b/.github/workflows/gem_deploy_ouroborus.yml
@@ -1,0 +1,32 @@
+name: Publish Ouroborus Gem
+
+on:
+  push:
+    tags:
+      - 'ouroborus*'
+
+jobs:
+  publish-gem:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0 
+
+      - name: Publish Ouroborus Gem to GitHub Registry
+        run: |
+          mkdir -p ~/.gem
+          echo ":github: Bearer ${{ secrets.GITHUB_TOKEN }}" > ~/.gem/credentials
+          chmod 0600 ~/.gem/credentials
+          cd ouroborus
+          gem build ouroborus.gemspec
+          gem push --key github --host https://rubygems.pkg.github.com/geosales-evolution ouroborus-*.gem


### PR DESCRIPTION
has an artificial dependency on  #52   

closes #53 beacause I couldn't make it run the CI to run my tests.

This is where the package will be located, in  the organization package section: 
![image](https://github.com/GeoSales-Evolution/self-deployable-docker/assets/38257122/7c15ba16-206e-473c-94a0-bfea1c903f2d)
